### PR TITLE
Update proxy.ashx

### DIFF
--- a/DotNet/README.md
+++ b/DotNet/README.md
@@ -5,6 +5,7 @@ A .NET proxy that handles support for
 * Accessing cross domain resources
 * Requests that exceed 2048 characters
 * Accessing resources secured with token based authentication.
+* Accessing resources secured with Microsoft Integrated Windows Authentication (IWA) by using the configured application pool identity for the hosted resource-proxy.
 * [OAuth 2.0 app logins](https://developers.arcgis.com/en/authentication).
 * Enabling logging
 * Both resource and referer based rate limiting

--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -17,6 +17,7 @@ using System.Web.Caching;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using System.Net;
 
 public class proxy : IHttpHandler {
 
@@ -231,8 +232,11 @@ public class proxy : IHttpHandler {
         {
             requestUri = serverUrl.HostRedirect + new Uri(requestUri).PathAndQuery;
         }
-
-        if (serverUrl.Domain != null)
+        if (serverUrl.UseAppPoolIdentity)
+	    {
+		    credentials=CredentialCache.DefaultNetworkCredentials;
+	    }
+    	else if (serverUrl.Domain != null)
         {
             credentials = new System.Net.NetworkCredential(serverUrl.Username, serverUrl.Password, serverUrl.Domain);
         }
@@ -1034,6 +1038,7 @@ public class ServerUrl {
     bool matchAll;
     string oauth2Endpoint;
     string domain;
+    bool useAppPoolIdentity;
     string username;
     string password;
     string clientId;
@@ -1078,6 +1083,12 @@ public class ServerUrl {
     {
         get { return domain; }
         set { domain = value; }
+    }
+    [XmlAttribute("useAppPoolIdentity")]
+    public bool UseAppPoolIdentity
+    {
+        get { return useAppPoolIdentity; }
+        set { useAppPoolIdentity = value; }
     }
     [XmlAttribute("username")]
     public string Username {

--- a/DotNet/proxy.xsd
+++ b/DotNet/proxy.xsd
@@ -10,6 +10,7 @@
                                 <xs:complexType>
                                     <xs:attribute name="url" type="xs:string" use="required" />
                                     <xs:attribute name="matchAll" type="xs:boolean" use="required" />
+                                    <xs:attribute name="useAppPoolIdentity" type="xs:boolean" use="optional" />
                                     <xs:attribute name="username" type="xs:string" use="optional" />
                                     <xs:attribute name="password" type="xs:string" use="optional" />
                                     <xs:attribute name="domain" type="xs:string" use="optional" />

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All three proxies respect the XML configuration properties listed below.
     * **username**: Username to use when requesting a token - if needed for ArcGIS Server token based authentication.
     * **password**: Password to use when requesting a token - if needed for ArcGIS Server token based authentication.
     * **tokenServiceUri**: If username and password are specified, the proxy will use the supplied token service uri to request a token.  If this value is left blank, the proxy will request a token URL from the ArcGIS server.
-    * **domain**: The Windows domain to use with username/password when using Windows Authentication. Only applies to DotNet proxy.
+* **useAppPoolIdentity**: The IIS application pool identity will be used for authenticating with secured resources.  This configuration will supersede the domain, username, and password configurations.  Only applies to DotNet proxy.    * **domain**: The Windows domain to use with username/password when using Windows Authentication. Only applies to DotNet proxy.
     * **clientId**.  Used with clientSecret for OAuth authentication to obtain a token - if needed for OAuth 2.0 authentication. **NOTE**: If used to access hosted services, the service(s) must be owned by the user accessing it, (with the exception of credit-based esri services, e.g. routing, geoenrichment, etc.)
     * **clientSecret**: Used with clientId for OAuth authentication to obtain a token - if needed for OAuth 2.0 authentication.
     * **oauth2Endpoint**: When using OAuth 2.0 authentication specify the portal specific OAuth 2.0 authentication endpoint. The default value is https://www.arcgis.com/sharing/oauth2/.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ All three proxies respect the XML configuration properties listed below.
     * **username**: Username to use when requesting a token - if needed for ArcGIS Server token based authentication.
     * **password**: Password to use when requesting a token - if needed for ArcGIS Server token based authentication.
     * **tokenServiceUri**: If username and password are specified, the proxy will use the supplied token service uri to request a token.  If this value is left blank, the proxy will request a token URL from the ArcGIS server.
-    * * **useAppPoolIdentity**: The IIS application pool identity will be used for authenticating with secured resources.  This configuration will supersede the domain, username, and password configurations.  Only applies to DotNet proxy.
-    * * **domain**: The Windows domain to use with username/password when using Windows Authentication. Only applies to DotNet proxy.
+    * **useAppPoolIdentity**: The IIS application pool identity will be used for authenticating with secured resources.  This configuration will supersede the domain, username, and password configurations.  Only applies to DotNet proxy.
+    * **domain**: The Windows domain to use with username/password when using Windows Authentication. Only applies to DotNet proxy.
     * **clientId**.  Used with clientSecret for OAuth authentication to obtain a token - if needed for OAuth 2.0 authentication. **NOTE**: If used to access hosted services, the service(s) must be owned by the user accessing it, (with the exception of credit-based esri services, e.g. routing, geoenrichment, etc.)
     * **clientSecret**: Used with clientId for OAuth authentication to obtain a token - if needed for OAuth 2.0 authentication.
     * **oauth2Endpoint**: When using OAuth 2.0 authentication specify the portal specific OAuth 2.0 authentication endpoint. The default value is https://www.arcgis.com/sharing/oauth2/.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ All three proxies respect the XML configuration properties listed below.
     * **username**: Username to use when requesting a token - if needed for ArcGIS Server token based authentication.
     * **password**: Password to use when requesting a token - if needed for ArcGIS Server token based authentication.
     * **tokenServiceUri**: If username and password are specified, the proxy will use the supplied token service uri to request a token.  If this value is left blank, the proxy will request a token URL from the ArcGIS server.
-* **useAppPoolIdentity**: The IIS application pool identity will be used for authenticating with secured resources.  This configuration will supersede the domain, username, and password configurations.  Only applies to DotNet proxy.    * **domain**: The Windows domain to use with username/password when using Windows Authentication. Only applies to DotNet proxy.
+    * * **useAppPoolIdentity**: The IIS application pool identity will be used for authenticating with secured resources.  This configuration will supersede the domain, username, and password configurations.  Only applies to DotNet proxy.
+    * * **domain**: The Windows domain to use with username/password when using Windows Authentication. Only applies to DotNet proxy.
     * **clientId**.  Used with clientSecret for OAuth authentication to obtain a token - if needed for OAuth 2.0 authentication. **NOTE**: If used to access hosted services, the service(s) must be owned by the user accessing it, (with the exception of credit-based esri services, e.g. routing, geoenrichment, etc.)
     * **clientSecret**: Used with clientId for OAuth authentication to obtain a token - if needed for OAuth 2.0 authentication.
     * **oauth2Endpoint**: When using OAuth 2.0 authentication specify the portal specific OAuth 2.0 authentication endpoint. The default value is https://www.arcgis.com/sharing/oauth2/.


### PR DESCRIPTION
Add additional boolean 'useAppPoolIdentity' property to the ServerUrl object that will trump the 'domain', 'username' and 'password' properties.  This 'useAppPoolIdentity' will inherit the configured IIS Application Pool identity by using the 'CredentialCache.DefaultNetworkCredentials' in 'System.Net' .
